### PR TITLE
Fix: Use dtolnay/rust-toolchain to avoid set-output warning

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,11 +21,9 @@ jobs:
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
+          components: rustfmt, clippy
 
       - name: Check formatting
         run: cargo fmt --all -- --check


### PR DESCRIPTION
The actions-rs/toolchain action is archived and uses the deprecated set-output command. This commit replaces it with dtolnay/rust-toolchain, which is actively maintained and does not produce the warning.