### PR TITLE
fix(deps): Enable display feature for derive_more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,6 +567,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+ "unicode-xid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ tonic = { version = "0.14", features = ["zstd", "tls-native-roots"] }
 fastrace = { version = "0.7", features = ["enable"] }
 starlark = "0.13"
 allocative = "0.3"
-derive_more = "2.0.0"
+derive_more = { version = "2.0.0", features = ["display"] }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1.0"
 erased-serde = "0.4"


### PR DESCRIPTION
The CI was failing with a compilation error in the 'derive_more' crate. The error message "at least one derive feature must be enabled" indicates that the crate was being compiled without any of its features enabled.

This change explicitly enables the "display" feature for the 'derive_more' dependency in Cargo.toml to resolve the issue, as requested by the user.