### PR TITLE
Refactor expand_pattern to return a stream of Labels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2166,6 +2188,7 @@ dependencies = [
  "assert_cmd",
  "assert_fs",
  "async-recursion",
+ "async-stream",
  "bazel-remote-apis",
  "chumsky",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tracing-subscriber = "0.3.19"
 console-subscriber = "0.5.0"
 chumsky = { version = "0.13.0" }
 dynosaur = "0.3.0"
+async-stream = "0.3"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/bazel/label.rs
+++ b/src/bazel/label.rs
@@ -16,9 +16,11 @@ impl<'a> ApparentRepo<'a> {
     pub fn as_str(&self) -> &str {
         self.0.as_ref()
     }
-}
 
-impl<'a> ApparentRepo<'a> {
+    pub fn into_owned(self) -> ApparentRepo<'static> {
+        ApparentRepo(Cow::Owned(self.0.into_owned()))
+    }
+
     pub fn into_name(self) -> Cow<'a, str> {
         self.0
     }
@@ -48,9 +50,11 @@ impl<'a> CanonicalRepo<'a> {
     pub fn as_str(&self) -> &str {
         self.0.as_ref()
     }
-}
 
-impl<'a> CanonicalRepo<'a> {
+    pub fn into_owned(self) -> CanonicalRepo<'static> {
+        CanonicalRepo(Cow::Owned(self.0.into_owned()))
+    }
+
     pub fn into_name(self) -> Cow<'a, str> {
         self.0
     }
@@ -79,6 +83,13 @@ impl<'a> Repo<'a> {
         match self {
             Repo::Apparent(r) => r.into_name(),
             Repo::Canonical(r) => r.into_name(),
+        }
+    }
+
+    pub fn into_owned(self) -> Repo<'static> {
+        match self {
+            Repo::Apparent(r) => Repo::Apparent(r.into_owned()),
+            Repo::Canonical(r) => Repo::Canonical(r.into_owned()),
         }
     }
 }
@@ -223,6 +234,24 @@ impl<'a> ApparentLabel<'a> {
             target: self.target,
         })
     }
+
+    pub fn into_owned(self) -> ApparentLabel<'static> {
+        ApparentLabel {
+            repo: self.repo.into_owned(),
+            package: Cow::Owned(self.package.into_owned()),
+            target: Cow::Owned(self.target.into_owned()),
+        }
+    }
+}
+
+impl<'a> CanonicalLabel<'a> {
+    pub fn into_owned(self) -> CanonicalLabel<'static> {
+        CanonicalLabel {
+            repo: self.repo.into_owned(),
+            package: Cow::Owned(self.package.into_owned()),
+            target: Cow::Owned(self.target.into_owned()),
+        }
+    }
 }
 
 impl<'a> Label<'a, Repo<'a>> {
@@ -258,6 +287,14 @@ impl<'a> Label<'a, Repo<'a>> {
             package: self.package,
             target: self.target,
         })
+    }
+
+    pub fn into_owned(self) -> Label<'static, Repo<'static>> {
+        Label {
+            repo: self.repo.into_owned(),
+            package: Cow::Owned(self.package.into_owned()),
+            target: Cow::Owned(self.target.into_owned()),
+        }
     }
 }
 

--- a/src/bazel/label.rs
+++ b/src/bazel/label.rs
@@ -51,6 +51,10 @@ impl<'a> CanonicalRepo<'a> {
         self.0.as_ref()
     }
 
+    pub fn as_borrowed(&self) -> CanonicalRepo<'_> {
+        CanonicalRepo(Cow::Borrowed(self.0.as_ref()))
+    }
+
     pub fn into_owned(self) -> CanonicalRepo<'static> {
         CanonicalRepo(Cow::Owned(self.0.into_owned()))
     }

--- a/src/bazel/mod.rs
+++ b/src/bazel/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod bzlmod;
 pub(crate) mod label;
 pub(crate) mod package;
 pub(crate) mod repo;
+pub(crate) mod rule;
 
 #[derive(Debug)]
 #[allow(dead_code)]

--- a/src/bazel/package.rs
+++ b/src/bazel/package.rs
@@ -81,15 +81,15 @@ impl<F: FileStore> Package<F> {
                 stack.extend(subdirs);
 
                 // If this directory has a BUILD file, yield it as a subpackage (skip if it's the root package itself)
-                if let Some(bf) = build_file_name {
-                    if current_dir != self.path {
-                        let build_path = if current_dir.is_empty() { bf.clone() } else { format!("{}/{}", current_dir, bf) };
-                        match self.filestore.read_file(&build_path).await {
-                            Ok(file) => {
-                                yield Package::new(current_dir, bf, self.filestore.clone(), file);
-                            }
-                            Err(e) => yield Err(anyhow::Error::from(e))?,
+                if let Some(bf) = build_file_name
+                    && current_dir != self.path
+                {
+                    let build_path = if current_dir.is_empty() { bf.clone() } else { format!("{}/{}", current_dir, bf) };
+                    match self.filestore.read_file(&build_path).await {
+                        Ok(file) => {
+                            yield Package::new(current_dir, bf, self.filestore.clone(), file);
                         }
+                        Err(e) => yield Err(anyhow::Error::from(e))?,
                     }
                 }
             }

--- a/src/bazel/package.rs
+++ b/src/bazel/package.rs
@@ -22,13 +22,31 @@ impl<F: FileStore> Package<F> {
         }
     }
 
-    pub fn sub_packages(&self) -> Vec<String> {
+    pub async fn subpackages(&self) -> impl Stream<Item = anyhow::Result<Package<F>>> {
         // TODO: Implement this
-        vec![]
+        futures::stream::once(futures::future::ready(Err(anyhow::anyhow!(
+            "Not implemented"
+        ))))
+    }
+
+    // TODO
+    // pub async fn targets(&self) -> impl Stream<Item = anyhow::Result<Target>> {
+    //     // TODO: Implement this
+    //     vec![]
+    // }
+
+    pub async fn source_files(&self) -> impl Stream<Item = anyhow::Result<String>> {
+        // TODO: Implement this
+        futures::stream::once(futures::future::ready(Err(anyhow::anyhow!(
+            "Not implemented"
+        ))))
     }
 }
 
-use futures::future::{BoxFuture, FutureExt};
+use futures::{
+    Stream,
+    future::{BoxFuture, FutureExt},
+};
 
 pub type BoxAsyncRead = Box<dyn io::AsyncRead + Unpin + Send>;
 pub type BoxFile<'a> = Box<DynFile<'a, BoxAsyncRead>>;

--- a/src/bazel/package.rs
+++ b/src/bazel/package.rs
@@ -7,26 +7,93 @@ use tokio::io;
 pub use bazel_remote_apis::build::bazel::remote::execution::v2::Digest;
 pub use bazel_remote_apis::build::bazel::remote::execution::v2::digest_function::Value as DigestFunction;
 
+pub enum DirEntry {
+    File(String),
+    Directory(String),
+}
+
 // A package is a directory with a BUILD file.
 #[derive(Debug)]
 pub struct Package<F: FileStore> {
+    pub path: String,
+    pub build_file_name: String,
     _build_file: F::File,
-    _filestore: F,
+    pub filestore: F,
 }
 
 impl<F: FileStore> Package<F> {
-    pub fn new(filestore: F, build_file: F::File) -> Self {
+    pub fn new(path: String, build_file_name: String, filestore: F, build_file: F::File) -> Self {
         Self {
+            path,
+            build_file_name,
             _build_file: build_file,
-            _filestore: filestore,
+            filestore,
         }
     }
 
-    pub async fn subpackages(&self) -> impl Stream<Item = anyhow::Result<Package<F>>> {
-        // TODO: Implement this
-        futures::stream::once(futures::future::ready(Err(anyhow::anyhow!(
-            "Not implemented"
-        ))))
+    pub fn subpackages<'a>(&'a self) -> futures::stream::BoxStream<'a, anyhow::Result<Package<F>>>
+    where
+        F: Clone + 'a,
+    {
+        Box::pin(async_stream::try_stream! {
+            let mut stack = vec![self.path.clone()];
+
+            while let Some(current_dir) = stack.pop() {
+                // Read the directory contents
+                let mut dir_entries = match self.filestore.read_dir(&current_dir).await {
+                    Ok(entries) => entries,
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                    Err(e) => {
+                        yield Err(anyhow::Error::from(e))?;
+                        continue;
+                    }
+                };
+
+                let mut subdirs = Vec::new();
+                let mut build_file_name = None;
+
+                for entry in dir_entries {
+                    match entry {
+                        DirEntry::Directory(name) => {
+                            let name_str = name.as_str();
+                            if name_str.starts_with('.') || name_str == "target" || name_str.starts_with("bazel-") {
+                                continue;
+                            }
+                            let next_path = if current_dir.is_empty() {
+                                name
+                            } else {
+                                format!("{}/{}", current_dir, name)
+                            };
+                            subdirs.push(next_path);
+                        }
+                        DirEntry::File(name) => {
+                            if name == "BUILD.bazel" {
+                                build_file_name = Some("BUILD.bazel".to_string());
+                            } else if name == "BUILD" && build_file_name.is_none() {
+                                build_file_name = Some("BUILD".to_string());
+                            }
+                        }
+                    }
+                }
+
+                // Add subdirectories to the stack to continue walking
+                // (We do this even if we found a BUILD file here, as Bazel //... walks past package boundaries)
+                stack.extend(subdirs);
+
+                // If this directory has a BUILD file, yield it as a subpackage (skip if it's the root package itself)
+                if let Some(bf) = build_file_name {
+                    if current_dir != self.path {
+                        let build_path = if current_dir.is_empty() { bf.clone() } else { format!("{}/{}", current_dir, bf) };
+                        match self.filestore.read_file(&build_path).await {
+                            Ok(file) => {
+                                yield Package::new(current_dir, bf, self.filestore.clone(), file);
+                            }
+                            Err(e) => yield Err(anyhow::Error::from(e))?,
+                        }
+                    }
+                }
+            }
+        })
     }
 
     // TODO
@@ -84,7 +151,7 @@ pub trait FileStore: Send + Sync + std::fmt::Debug {
     /// Read a directory within the repository.
     ///
     /// The path is relative to the repository root.
-    fn read_dir(&self, path: &str) -> BoxFuture<'_, Result<Vec<String>, std::io::Error>>;
+    fn read_dir(&self, path: &str) -> BoxFuture<'_, Result<Vec<DirEntry>, std::io::Error>>;
 }
 
 impl<'a, F: File> std::fmt::Debug for DynFileStore<'a, F> {
@@ -126,7 +193,7 @@ impl<F: FileStore + ?Sized> FileStore for std::sync::Arc<F> {
         (**self).read_file(path)
     }
 
-    fn read_dir(&self, path: &str) -> BoxFuture<'_, Result<Vec<String>, std::io::Error>> {
+    fn read_dir(&self, path: &str) -> BoxFuture<'_, Result<Vec<DirEntry>, std::io::Error>> {
         (**self).read_dir(path)
     }
 }
@@ -152,7 +219,7 @@ where
         .boxed()
     }
 
-    fn read_dir(&self, path: &str) -> BoxFuture<'_, std::io::Result<Vec<String>>> {
+    fn read_dir(&self, path: &str) -> BoxFuture<'_, std::io::Result<Vec<DirEntry>>> {
         self.0.read_dir(path).boxed()
     }
 }

--- a/src/bazel/repo.rs
+++ b/src/bazel/repo.rs
@@ -4,9 +4,10 @@ use futures::future::{BoxFuture, FusedFuture, FutureExt};
 
 use crate::{
     bazel::{
-        label::{ApparentRepo, CanonicalRepo, MAIN_REPO},
+        label::{ApparentRepo, CanonicalLabel, CanonicalRepo, Label, MAIN_REPO},
         package::{
-            BoxFile, BoxFileStore, Digest, DigestFunction, DynFileStore, File, FileStore, Package,
+            BoxFile, BoxFileStore, Digest, DigestFunction, DirEntry, DynFileStore, File, FileStore,
+            Package,
         },
     },
     workspace::Workspace,
@@ -79,6 +80,27 @@ impl<'a> Repository<'a> {
         self.canonical_name.clone()
     }
 
+    /// Resolves an apparent repository name in this repository's mapping.
+    pub fn resolve_repo<'repo>(
+        &'repo self,
+        apparent: &ApparentRepo<'repo>,
+    ) -> Option<CanonicalRepo<'repo>>
+    where
+        'a: 'repo,
+    {
+        self.repo_mapping
+            .get(apparent)
+            .map(CanonicalRepo::as_borrowed)
+    }
+
+    /// Resolves the apparent repository portion of a label in this repository's mapping.
+    pub fn resolve_label<'repo>(&'repo self, label: Label<'repo>) -> Option<CanonicalLabel<'repo>>
+    where
+        'a: 'repo,
+    {
+        label.into_canonical(|apparent| self.resolve_repo(apparent))
+    }
+
     pub fn files(&self) -> &BoxFileStore<'a> {
         &self.files
     }
@@ -89,8 +111,16 @@ impl<'a> Repository<'a> {
     ) -> Result<Package<BoxFileStore<'a>>, std::io::Error> {
         // Bazel looks for BUILD.bazel first, then BUILD. It's an error if both exist.
         // We read both in parallel to maximize performance.
-        let build_bazel_path = format!("{pkg}/BUILD.bazel");
-        let build_path = format!("{pkg}/BUILD");
+        let build_bazel_path = if pkg.is_empty() {
+            "BUILD.bazel".to_string()
+        } else {
+            format!("{pkg}/BUILD.bazel")
+        };
+        let build_path = if pkg.is_empty() {
+            "BUILD".to_string()
+        } else {
+            format!("{pkg}/BUILD")
+        };
 
         let (build_bazel_result, build_result) = tokio::join!(
             self.read_file(&build_bazel_path),
@@ -99,13 +129,19 @@ impl<'a> Repository<'a> {
 
         match (build_bazel_result, build_result) {
             // Success case 1: BUILD.bazel exists, BUILD does not.
-            (Ok(file), Err(e)) if e.kind() == std::io::ErrorKind::NotFound => {
-                Ok(Package::new(self.files.clone(), file))
-            }
+            (Ok(file), Err(e)) if e.kind() == std::io::ErrorKind::NotFound => Ok(Package::new(
+                pkg.to_string(),
+                "BUILD.bazel".to_string(),
+                self.files.clone(),
+                file,
+            )),
             // Success case 2: BUILD.bazel does not exist, BUILD does.
-            (Err(e), Ok(file)) if e.kind() == std::io::ErrorKind::NotFound => {
-                Ok(Package::new(self.files.clone(), file))
-            }
+            (Err(e), Ok(file)) if e.kind() == std::io::ErrorKind::NotFound => Ok(Package::new(
+                pkg.to_string(),
+                "BUILD".to_string(),
+                self.files.clone(),
+                file,
+            )),
             // Error case 1: Both exist.
             (Ok(_), Ok(_)) => Err(std::io::Error::new(
                 std::io::ErrorKind::AlreadyExists,
@@ -132,8 +168,25 @@ impl<'a> Repository<'a> {
         self.files.read_file(path).await
     }
 
-    pub async fn read_dir(&self, path: &str) -> Result<Vec<String>, std::io::Error> {
+    pub async fn read_dir(&self, path: &str) -> Result<Vec<DirEntry>, std::io::Error> {
         self.files.read_dir(path).await
+    }
+
+    pub async fn eval_package(
+        self: &std::sync::Arc<Self>,
+        pkg: &Package<BoxFileStore<'a>>,
+        workspace: std::sync::Arc<Workspace>,
+    ) -> anyhow::Result<HashMap<String, crate::bazel::rule::Rule>>
+    where
+        'a: 'static,
+    {
+        let build_path = if pkg.path.is_empty() {
+            pkg.build_file_name.clone()
+        } else {
+            format!("{}/{}", pkg.path, pkg.build_file_name)
+        };
+
+        crate::starlark::eval::eval_build(workspace, self.clone(), &build_path).await
     }
 }
 
@@ -167,14 +220,19 @@ impl FileStore for LocalFileStore {
         .boxed()
     }
 
-    fn read_dir(&self, path: &str) -> BoxFuture<'_, Result<Vec<String>, std::io::Error>> {
+    fn read_dir(&self, path: &str) -> BoxFuture<'_, Result<Vec<DirEntry>, std::io::Error>> {
         let full_path = self.root.join(path);
         async move {
             let mut read_dir = fs::read_dir(full_path).await?;
             let mut results = Vec::new();
 
             while let Some(entry) = read_dir.next_entry().await? {
-                results.push(entry.file_name().to_string_lossy().to_string());
+                let name = entry.file_name().to_string_lossy().to_string();
+                if entry.file_type().await?.is_dir() {
+                    results.push(DirEntry::Directory(name));
+                } else {
+                    results.push(DirEntry::File(name));
+                }
             }
 
             Ok(results)
@@ -241,26 +299,35 @@ impl FileStore for InMemoryFileStore {
         .boxed()
     }
 
-    fn read_dir(&self, path: &str) -> BoxFuture<'_, Result<Vec<String>, std::io::Error>> {
+    fn read_dir(&self, path: &str) -> BoxFuture<'_, Result<Vec<DirEntry>, std::io::Error>> {
         let dir_path = std::path::PathBuf::from(path);
         async move {
-            let results: HashSet<_> = self
-                .files
-                .keys()
-                .filter_map(|file_path_str| {
-                    std::path::Path::new(file_path_str)
-                        .strip_prefix(&dir_path)
-                        .ok()
-                        .and_then(|p| p.components().next())
-                        .and_then(|c| match c {
-                            std::path::Component::Normal(name) => {
-                                Some(name.to_string_lossy().into_owned())
+            let mut entries = HashMap::new();
+            for file_path_str in self.files.keys() {
+                if let Ok(stripped) = std::path::Path::new(file_path_str).strip_prefix(&dir_path) {
+                    let mut components = stripped.components();
+                    if let Some(first) = components.next() {
+                        if let std::path::Component::Normal(name) = first {
+                            let name_str = name.to_string_lossy().into_owned();
+                            if components.next().is_some() {
+                                entries.insert(name_str, true);
+                            } else {
+                                entries.entry(name_str).or_insert(false);
                             }
-                            _ => None,
-                        })
+                        }
+                    }
+                }
+            }
+            Ok(entries
+                .into_iter()
+                .map(|(name, is_directory)| {
+                    if is_directory {
+                        DirEntry::Directory(name)
+                    } else {
+                        DirEntry::File(name)
+                    }
                 })
-                .collect();
-            Ok(results.into_iter().collect())
+                .collect())
         }
         .boxed()
     }
@@ -290,8 +357,59 @@ impl File for InMemoryFile {
 #[cfg(test)]
 pub mod test {
     use super::*;
+    use crate::bazel::label::Repo;
     use std::collections::HashMap;
     use tokio::io::{self};
+
+    #[test]
+    fn test_resolve_repo_and_label() {
+        let files: BoxFileStore<'static> = std::sync::Arc::from(DynFileStore::new_box(Box::new(
+            crate::bazel::package::TypeErasingFileStore(InMemoryFileStore::new(HashMap::new())),
+        )));
+        let canonical_dep = CanonicalRepo::new(String::from("dep+1.0"));
+        let repo = Repository {
+            repo_name: ApparentRepo::new("root"),
+            canonical_name: MAIN_REPO,
+            repo_mapping: HashMap::from([(ApparentRepo::new("dep_alias"), canonical_dep.clone())]),
+            files,
+        };
+
+        let apparent_name = String::from("dep_alias");
+        let stored = repo.repo_mapping.values().next().unwrap();
+        let resolved = repo
+            .resolve_repo(&ApparentRepo::new(apparent_name.as_str()))
+            .unwrap();
+        assert_eq!(resolved, canonical_dep);
+        assert!(std::ptr::eq(resolved.as_str(), stored.as_str()));
+        assert_eq!(repo.resolve_repo(&ApparentRepo::new("unknown")), None);
+
+        let apparent_label = Label::new(
+            Repo::Apparent(ApparentRepo::new(apparent_name.as_str())),
+            "package",
+            "target",
+        );
+        let resolved_label = repo.resolve_label(apparent_label).unwrap();
+        assert_eq!(resolved_label.repo, canonical_dep);
+        assert_eq!(resolved_label.package, "package");
+        assert_eq!(resolved_label.target, "target");
+
+        let canonical_label = Label::new(
+            Repo::Canonical(CanonicalRepo::new("already_canonical")),
+            "package",
+            "target",
+        );
+        assert_eq!(
+            repo.resolve_label(canonical_label).unwrap().repo,
+            CanonicalRepo::new("already_canonical")
+        );
+
+        let unknown_label = Label::new(
+            Repo::Apparent(ApparentRepo::new("unknown")),
+            "package",
+            "target",
+        );
+        assert!(repo.resolve_label(unknown_label).is_none());
+    }
 
     #[tokio::test]
     async fn test_in_memory_file_store_read_dir() {
@@ -305,19 +423,46 @@ pub mod test {
         let store = InMemoryFileStore::new(files);
 
         // Test root directory
-        let mut root_entries = store.read_dir("").await.unwrap();
+        let mut root_entries: Vec<String> = store
+            .read_dir("")
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|e| match e {
+                DirEntry::File(s) => s,
+                DirEntry::Directory(s) => s,
+            })
+            .collect();
         root_entries.sort();
         assert_eq!(root_entries, vec!["a", "f"]);
 
         // Test subdirectory "a" (with and without trailing slash)
         for path in ["a", "a/"] {
-            let mut entries = store.read_dir(path).await.unwrap();
+            let mut entries: Vec<String> = store
+                .read_dir(path)
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|e| match e {
+                    DirEntry::File(s) => s,
+                    DirEntry::Directory(s) => s,
+                })
+                .collect();
             entries.sort();
             assert_eq!(entries, vec!["b", "c", "d"], "Failed for path: {path}");
         }
 
         // Test deeper subdirectory "a/d"
-        let mut ad_entries = store.read_dir("a/d").await.unwrap();
+        let mut ad_entries: Vec<String> = store
+            .read_dir("a/d")
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|e| match e {
+                DirEntry::File(s) => s,
+                DirEntry::Directory(s) => s,
+            })
+            .collect();
         ad_entries.sort();
         assert_eq!(ad_entries, vec!["e"]);
 

--- a/src/bazel/repo.rs
+++ b/src/bazel/repo.rs
@@ -306,14 +306,12 @@ impl FileStore for InMemoryFileStore {
             for file_path_str in self.files.keys() {
                 if let Ok(stripped) = std::path::Path::new(file_path_str).strip_prefix(&dir_path) {
                     let mut components = stripped.components();
-                    if let Some(first) = components.next() {
-                        if let std::path::Component::Normal(name) = first {
-                            let name_str = name.to_string_lossy().into_owned();
-                            if components.next().is_some() {
-                                entries.insert(name_str, true);
-                            } else {
-                                entries.entry(name_str).or_insert(false);
-                            }
+                    if let Some(std::path::Component::Normal(name)) = components.next() {
+                        let name_str = name.to_string_lossy().into_owned();
+                        if components.next().is_some() {
+                            entries.insert(name_str, true);
+                        } else {
+                            entries.entry(name_str).or_insert(false);
                         }
                     }
                 }

--- a/src/bazel/rule.rs
+++ b/src/bazel/rule.rs
@@ -1,0 +1,8 @@
+use allocative::Allocative;
+
+#[derive(Debug, Clone, Allocative)]
+pub struct Rule {
+    pub rule_class: String,
+    pub name: String,
+    // Add additional rule attributes here as needed later
+}

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,5 +1,5 @@
 use crate::bazel::Configuration;
-use crate::bazel::label::{Label, MAIN_REPO_ROOT, Repo, parse_label};
+use crate::bazel::label::{Label, MAIN_REPO_ROOT, Repo};
 use crate::stream_tee::{StreamTee, StreamTeeExt};
 use crate::workspace::Workspace;
 use chumsky::prelude::*;
@@ -16,13 +16,12 @@ pub type QueryStream<'a> = BoxStream<'a, QueryResult<'a>>;
 
 #[derive(Clone)]
 pub struct QueryContext<'a> {
-    #[allow(dead_code)]
-    pub workspace: &'a Workspace,
+    pub workspace: Arc<Workspace>,
     pub variables: HashMap<&'a str, StreamTee<QueryStream<'a>>>,
 }
 
 impl<'a> QueryContext<'a> {
-    pub fn new(workspace: &'a Workspace) -> Self {
+    pub fn new(workspace: Arc<Workspace>) -> Self {
         Self {
             workspace,
             variables: HashMap::new(),
@@ -183,12 +182,24 @@ pub fn parser<'a>() -> impl Parser<'a, &'a str, Spanned<Expr<'a>>, extra::Err<Ri
 impl<'a> Expr<'a> {
     pub fn eval(&self, ctx: &QueryContext<'a>) -> QueryStream<'a> {
         match self {
-            Expr::String(s) => {
-                // TODO: this should be interpreted as a pattern rather than just a single label
-                match parse_label(s, &MAIN_REPO_ROOT) {
-                    Ok(label) => stream::once(async move { Ok(label) }).boxed(),
-                    Err(e) => stream::once(async move { Err(e.to_string()) }).boxed(),
-                }
+            &Expr::String(s) => {
+                let ws = ctx.workspace.clone();
+                let fut = async move {
+                    match crate::bazel::label::parse_target_pattern(s, &MAIN_REPO_ROOT) {
+                        Ok(pattern) => {
+                            ws.expand_pattern(pattern)
+                                .map(|res| match res {
+                                    Ok(label) => Ok(label),
+                                    Err(e) => Err(e.to_string()),
+                                })
+                                .boxed()
+                        }
+                        Err(e) => {
+                            stream::once(async move { Err(e.to_string()) }).boxed()
+                        }
+                    }
+                };
+                stream::once(fut).flatten().boxed()
             }
             Expr::Int(_) => {
                 stream::once(async { Err("Int not supported out of function context".to_string()) })
@@ -280,7 +291,7 @@ where
     })?;
 
     // Evaluate the query!
-    let mut result_stream = ast.inner.eval(&QueryContext::new(&workspace));
+    let mut result_stream = ast.inner.eval(&QueryContext::new(workspace.clone()));
 
     while let Some(res) = result_stream.next().await {
         match res {

--- a/src/query.rs
+++ b/src/query.rs
@@ -186,17 +186,14 @@ impl<'a> Expr<'a> {
                 let ws = ctx.workspace.clone();
                 let fut = async move {
                     match crate::bazel::label::parse_target_pattern(s, &MAIN_REPO_ROOT) {
-                        Ok(pattern) => {
-                            ws.expand_pattern(pattern)
-                                .map(|res| match res {
-                                    Ok(label) => Ok(label),
-                                    Err(e) => Err(e.to_string()),
-                                })
-                                .boxed()
-                        }
-                        Err(e) => {
-                            stream::once(async move { Err(e.to_string()) }).boxed()
-                        }
+                        Ok(pattern) => ws
+                            .expand_pattern(pattern)
+                            .map(|res| match res {
+                                Ok(label) => Ok(label),
+                                Err(e) => Err(e.to_string()),
+                            })
+                            .boxed(),
+                        Err(e) => stream::once(async move { Err(e.to_string()) }).boxed(),
                     }
                 };
                 stream::once(fut).flatten().boxed()

--- a/src/starlark/eval.rs
+++ b/src/starlark/eval.rs
@@ -86,19 +86,11 @@ pub async fn eval_bzl_recursive(
                         anyhow::anyhow!("Cannot resolve repo mapping for {:?}", load_str)
                     })?;
 
-                let canonical_load_static = crate::bazel::label::CanonicalLabel::new(
-                    crate::bazel::label::CanonicalRepo::new(
-                        canonical_load.repo.as_str().to_string(),
-                    ),
-                    canonical_load.package.to_string(),
-                    canonical_load.target.to_string(),
-                );
-
                 futures.push(
                     eval_bzl_recursive(
                         workspace_clone.clone(),
                         repo_clone.clone(),
-                        canonical_load_static,
+                        canonical_load.into_owned(),
                     )
                     .boxed(),
                 );
@@ -184,14 +176,8 @@ pub async fn eval_build(
             })
             .ok_or_else(|| anyhow::anyhow!("Cannot resolve repo mapping for {:?}", load_str))?;
 
-        let canonical_load_static = crate::bazel::label::CanonicalLabel::new(
-            crate::bazel::label::CanonicalRepo::new(canonical_load.repo.as_str().to_string()),
-            canonical_load.package.to_string(),
-            canonical_load.target.to_string(),
-        );
-
         futures.push(
-            eval_bzl_recursive(workspace.clone(), repo.clone(), canonical_load_static).boxed(),
+            eval_bzl_recursive(workspace.clone(), repo.clone(), canonical_load.into_owned()).boxed(),
         );
         module_ids.push(load_str.clone());
     }

--- a/src/starlark/eval.rs
+++ b/src/starlark/eval.rs
@@ -1,0 +1,225 @@
+use crate::bazel::label::{CanonicalLabel, Label};
+use crate::bazel::package::File;
+use crate::bazel::repo::Repository;
+use crate::bazel::rule::Rule;
+use crate::workspace::Workspace;
+use futures::future::{BoxFuture, FutureExt};
+use starlark::environment::{FrozenModule, Module as StarlarkModule};
+use starlark::eval::{Evaluator, FileLoader};
+use starlark::syntax::{AstModule, Dialect};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::io::AsyncReadExt;
+
+const DIALECT_BUILD: Dialect = Dialect {
+    enable_load: true,
+    ..Dialect::Standard
+};
+
+struct HashMapFileLoader<'a> {
+    modules: &'a HashMap<String, FrozenModule>,
+}
+
+impl<'a> FileLoader for HashMapFileLoader<'a> {
+    fn load(&self, module: &str) -> starlark::Result<FrozenModule> {
+        self.modules.get(module).cloned().ok_or_else(|| {
+            starlark::Error::new_native(anyhow::anyhow!("Module {} not loaded statically", module))
+        })
+    }
+}
+
+/// Recursively load, parse and freeze a starlark dependency
+#[async_recursion::async_recursion]
+pub async fn eval_bzl_recursive(
+    workspace: Arc<Workspace>,
+    repo: Arc<Repository<'static>>,
+    label: CanonicalLabel<'static>,
+) -> anyhow::Result<FrozenModule> {
+    let r = {
+        let workspace_clone = workspace.clone();
+        let repo_clone = repo.clone();
+        let label_clone = label.clone();
+        workspace.get_or_add_bzl(label.clone(), move || async move {
+            if repo_clone.canonical_name() != label_clone.repo {
+                anyhow::bail!(
+                    "eval_bzl_recursive cross-repo load unimplemented for {:?}",
+                    label_clone
+                );
+            }
+
+            let package = label_clone.package();
+            let target = label_clone.name();
+
+            let path = if package.is_empty() {
+                target.to_string()
+            } else {
+                format!("{}/{}", package, target)
+            };
+
+            let file = repo_clone.read_file(&path).await?;
+            let mut content = String::new();
+            (*file).open().await?.read_to_string(&mut content).await?;
+
+            let loads: Vec<String> = {
+                let ast = AstModule::parse(&path, content.clone(), &DIALECT_BUILD)
+                    .map_err(|e| e.into_anyhow())?;
+                ast.loads()
+                    .into_iter()
+                    .map(|l| l.module_id.to_string())
+                    .collect()
+            };
+
+            let mut loaded_modules = HashMap::new();
+            let mut futures: Vec<BoxFuture<'static, anyhow::Result<FrozenModule>>> = Vec::new();
+            let mut module_ids = Vec::new();
+
+            for load_str in &loads {
+                let load_label = crate::bazel::label::parse_label(load_str, &label_clone)
+                    .map_err(|e| anyhow::anyhow!("Failed to parse label: {:?}", e.to_string()))?;
+                let canonical_load = load_label
+                    .into_canonical(|r| {
+                        Some(crate::bazel::label::CanonicalRepo::new(
+                            r.as_str().to_string(),
+                        ))
+                    })
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("Cannot resolve repo mapping for {:?}", load_str)
+                    })?;
+
+                let canonical_load_static = crate::bazel::label::CanonicalLabel::new(
+                    crate::bazel::label::CanonicalRepo::new(
+                        canonical_load.repo.as_str().to_string(),
+                    ),
+                    canonical_load.package.to_string(),
+                    canonical_load.target.to_string(),
+                );
+
+                futures.push(
+                    eval_bzl_recursive(
+                        workspace_clone.clone(),
+                        repo_clone.clone(),
+                        canonical_load_static,
+                    )
+                    .boxed(),
+                );
+                module_ids.push(load_str.clone());
+            }
+
+            let results = futures::future::try_join_all(futures).await?;
+            for (module_id, frozen) in module_ids.into_iter().zip(results) {
+                loaded_modules.insert(module_id, frozen);
+            }
+
+            let globals = super::globals::bzl::bzl_globals_builder().build();
+
+            let frozen_module = StarlarkModule::with_temp_heap(
+                |starlark_module| -> anyhow::Result<FrozenModule> {
+                    {
+                        let loader = HashMapFileLoader {
+                            modules: &loaded_modules,
+                        };
+                        let mut eval = Evaluator::new(&starlark_module);
+                        eval.set_loader(&loader);
+                        let ast = AstModule::parse(&path, content, &DIALECT_BUILD)
+                            .map_err(|e| e.into_anyhow())?;
+                        eval.eval_module(ast, &globals)
+                            .map_err(|e| e.into_anyhow())?;
+                    }
+                    starlark_module.freeze().map_err(anyhow::Error::from)
+                },
+            )?;
+
+            Ok(frozen_module)
+        })
+    };
+
+    r.await.map_err(anyhow::Error::new)
+}
+
+pub async fn eval_build(
+    workspace: Arc<Workspace>,
+    repo: Arc<Repository<'static>>,
+    path: &str, // e.g. "my_package/BUILD.bazel"
+) -> anyhow::Result<HashMap<String, Rule>> {
+    // 1. Construct contextual label
+    let parts: Vec<&str> = path.rsplitn(2, '/').collect();
+    let (package, target) = if parts.len() == 2 {
+        (parts[1], parts[0])
+    } else {
+        ("", parts[0])
+    };
+
+    let context_label = Label::new(
+        repo.canonical_name(),
+        package.to_string(),
+        target.to_string(),
+    );
+
+    let file = repo.read_file(path).await?;
+    let mut content = String::new();
+    (*file).open().await?.read_to_string(&mut content).await?;
+
+    let loads: Vec<String> = {
+        let ast =
+            AstModule::parse(path, content.clone(), &DIALECT_BUILD).map_err(|e| e.into_anyhow())?;
+        ast.loads()
+            .into_iter()
+            .map(|l| l.module_id.to_string())
+            .collect()
+    };
+
+    let mut loaded_modules = HashMap::new();
+    let mut futures: Vec<BoxFuture<'static, anyhow::Result<FrozenModule>>> = Vec::new();
+    let mut module_ids = Vec::new();
+
+    for load_str in &loads {
+        let load_label = crate::bazel::label::parse_label(load_str, &context_label)
+            .map_err(|e| anyhow::anyhow!("Failed to parse label: {:?}", e.to_string()))?;
+        let canonical_load = load_label
+            .into_canonical(|r| {
+                // TODO: use proper apparent repo resolution from the Repository
+                Some(crate::bazel::label::CanonicalRepo::new(
+                    r.as_str().to_string(),
+                ))
+            })
+            .ok_or_else(|| anyhow::anyhow!("Cannot resolve repo mapping for {:?}", load_str))?;
+
+        let canonical_load_static = crate::bazel::label::CanonicalLabel::new(
+            crate::bazel::label::CanonicalRepo::new(canonical_load.repo.as_str().to_string()),
+            canonical_load.package.to_string(),
+            canonical_load.target.to_string(),
+        );
+
+        futures.push(
+            eval_bzl_recursive(workspace.clone(), repo.clone(), canonical_load_static).boxed(),
+        );
+        module_ids.push(load_str.clone());
+    }
+
+    let results = futures::future::try_join_all(futures).await?;
+    for (module_id, frozen) in module_ids.into_iter().zip(results) {
+        loaded_modules.insert(module_id, frozen);
+    }
+
+    let globals = super::globals::build::build_globals_builder().build();
+
+    let extra = crate::starlark::globals::build::BuildExtra {
+        rules: std::cell::RefCell::new(HashMap::new()),
+    };
+
+    StarlarkModule::with_temp_heap(|starlark_module| {
+        let loader = HashMapFileLoader {
+            modules: &loaded_modules,
+        };
+        let mut eval = Evaluator::new(&starlark_module);
+        eval.set_loader(&loader);
+        eval.extra = Some(&extra);
+
+        let ast = AstModule::parse(path, content, &DIALECT_BUILD)?;
+        eval.eval_module(ast, &globals)?;
+        Ok::<_, starlark::Error>(())
+    })
+    .map_err(|e| e.into_anyhow())?;
+
+    Ok(extra.rules.into_inner())
+}

--- a/src/starlark/eval.rs
+++ b/src/starlark/eval.rs
@@ -76,15 +76,9 @@ pub async fn eval_bzl_recursive(
             for load_str in &loads {
                 let load_label = crate::bazel::label::parse_label(load_str, &label_clone)
                     .map_err(|e| anyhow::anyhow!("Failed to parse label: {:?}", e.to_string()))?;
-                let canonical_load = load_label
-                    .into_canonical(|r| {
-                        Some(crate::bazel::label::CanonicalRepo::new(
-                            r.as_str().to_string(),
-                        ))
-                    })
-                    .ok_or_else(|| {
-                        anyhow::anyhow!("Cannot resolve repo mapping for {:?}", load_str)
-                    })?;
+                let canonical_load = repo_clone.resolve_label(load_label).ok_or_else(|| {
+                    anyhow::anyhow!("Cannot resolve repo mapping for {:?}", load_str)
+                })?;
 
                 futures.push(
                     eval_bzl_recursive(
@@ -167,17 +161,13 @@ pub async fn eval_build(
     for load_str in &loads {
         let load_label = crate::bazel::label::parse_label(load_str, &context_label)
             .map_err(|e| anyhow::anyhow!("Failed to parse label: {:?}", e.to_string()))?;
-        let canonical_load = load_label
-            .into_canonical(|r| {
-                // TODO: use proper apparent repo resolution from the Repository
-                Some(crate::bazel::label::CanonicalRepo::new(
-                    r.as_str().to_string(),
-                ))
-            })
+        let canonical_load = repo
+            .resolve_label(load_label)
             .ok_or_else(|| anyhow::anyhow!("Cannot resolve repo mapping for {:?}", load_str))?;
 
         futures.push(
-            eval_bzl_recursive(workspace.clone(), repo.clone(), canonical_load.into_owned()).boxed(),
+            eval_bzl_recursive(workspace.clone(), repo.clone(), canonical_load.into_owned())
+                .boxed(),
         );
         module_ids.push(load_str.clone());
     }

--- a/src/starlark/globals/build.rs
+++ b/src/starlark/globals/build.rs
@@ -1,0 +1,138 @@
+use crate::bazel::rule::Rule;
+use starlark::any::ProvidesStaticType;
+use starlark::collections::SmallMap;
+use starlark::environment::GlobalsBuilder;
+use starlark::eval::Evaluator;
+use starlark::starlark_module;
+use starlark::values::Value;
+use starlark::values::none::NoneType;
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+#[derive(Debug, ProvidesStaticType)]
+pub(crate) struct BuildExtra {
+    pub rules: RefCell<HashMap<String, Rule>>,
+}
+
+pub(crate) fn build_globals_builder() -> GlobalsBuilder {
+    let mut b = GlobalsBuilder::standard();
+    build_globals(&mut b);
+    b
+}
+
+#[starlark_module]
+pub(crate) fn build_globals(builder: &mut GlobalsBuilder) {
+    fn rule(
+        #[starlark(kwargs)] _kwargs: SmallMap<&str, Value>,
+        _eval: &mut Evaluator,
+    ) -> starlark::Result<NoneType> {
+        Err(starlark::Error::new_native(anyhow::anyhow!(
+            "rule() not allowed in BUILD files"
+        )))
+    }
+
+    fn genrule(
+        #[starlark(require = named)] name: &str,
+        #[starlark(kwargs)] _kwargs: SmallMap<&str, Value>,
+        eval: &mut Evaluator,
+    ) -> starlark::Result<NoneType> {
+        if let Some(extra) = eval
+            .extra
+            .as_ref()
+            .and_then(|e| e.downcast_ref::<BuildExtra>())
+        {
+            extra.rules.borrow_mut().insert(
+                name.to_string(),
+                Rule {
+                    name: name.to_string(),
+                    rule_class: "genrule".to_string(),
+                },
+            );
+        }
+        Ok(NoneType)
+    }
+
+    fn cc_library(
+        #[starlark(require = named)] name: &str,
+        #[starlark(kwargs)] _kwargs: SmallMap<&str, Value>,
+        eval: &mut Evaluator,
+    ) -> starlark::Result<NoneType> {
+        if let Some(extra) = eval
+            .extra
+            .as_ref()
+            .and_then(|e| e.downcast_ref::<BuildExtra>())
+        {
+            extra.rules.borrow_mut().insert(
+                name.to_string(),
+                Rule {
+                    name: name.to_string(),
+                    rule_class: "cc_library".to_string(),
+                },
+            );
+        }
+        Ok(NoneType)
+    }
+
+    fn cc_binary(
+        #[starlark(require = named)] name: &str,
+        #[starlark(kwargs)] _kwargs: SmallMap<&str, Value>,
+        eval: &mut Evaluator,
+    ) -> starlark::Result<NoneType> {
+        if let Some(extra) = eval
+            .extra
+            .as_ref()
+            .and_then(|e| e.downcast_ref::<BuildExtra>())
+        {
+            extra.rules.borrow_mut().insert(
+                name.to_string(),
+                Rule {
+                    name: name.to_string(),
+                    rule_class: "cc_binary".to_string(),
+                },
+            );
+        }
+        Ok(NoneType)
+    }
+
+    fn filegroup(
+        #[starlark(require = named)] name: &str,
+        #[starlark(kwargs)] _kwargs: SmallMap<&str, Value>,
+        eval: &mut Evaluator,
+    ) -> starlark::Result<NoneType> {
+        if let Some(extra) = eval
+            .extra
+            .as_ref()
+            .and_then(|e| e.downcast_ref::<BuildExtra>())
+        {
+            extra.rules.borrow_mut().insert(
+                name.to_string(),
+                Rule {
+                    name: name.to_string(),
+                    rule_class: "filegroup".to_string(),
+                },
+            );
+        }
+        Ok(NoneType)
+    }
+
+    fn sh_binary(
+        #[starlark(require = named)] name: &str,
+        #[starlark(kwargs)] _kwargs: SmallMap<&str, Value>,
+        eval: &mut Evaluator,
+    ) -> starlark::Result<NoneType> {
+        if let Some(extra) = eval
+            .extra
+            .as_ref()
+            .and_then(|e| e.downcast_ref::<BuildExtra>())
+        {
+            extra.rules.borrow_mut().insert(
+                name.to_string(),
+                Rule {
+                    name: name.to_string(),
+                    rule_class: "sh_binary".to_string(),
+                },
+            );
+        }
+        Ok(NoneType)
+    }
+}

--- a/src/starlark/globals/bzl.rs
+++ b/src/starlark/globals/bzl.rs
@@ -1,0 +1,51 @@
+use starlark::collections::SmallMap;
+use starlark::environment::GlobalsBuilder;
+use starlark::eval::Evaluator;
+use starlark::starlark_module;
+use starlark::values::Value;
+use starlark::values::none::NoneType;
+
+pub(crate) fn bzl_globals_builder() -> GlobalsBuilder {
+    let mut b = GlobalsBuilder::standard();
+    bzl_globals(&mut b);
+    b
+}
+
+#[starlark_module]
+pub(crate) fn bzl_globals(builder: &mut GlobalsBuilder) {
+    fn rule(
+        #[starlark(kwargs)] _kwargs: SmallMap<&str, Value>,
+        _eval: &mut Evaluator,
+    ) -> starlark::Result<NoneType> {
+        Err(starlark::Error::new_native(anyhow::anyhow!(
+            "rule() unimplemented"
+        )))
+    }
+
+    fn provider(
+        #[starlark(kwargs)] _kwargs: SmallMap<&str, Value>,
+        _eval: &mut Evaluator,
+    ) -> starlark::Result<NoneType> {
+        Err(starlark::Error::new_native(anyhow::anyhow!(
+            "provider() unimplemented"
+        )))
+    }
+
+    fn aspect(
+        #[starlark(kwargs)] _kwargs: SmallMap<&str, Value>,
+        _eval: &mut Evaluator,
+    ) -> starlark::Result<NoneType> {
+        Err(starlark::Error::new_native(anyhow::anyhow!(
+            "aspect() unimplemented"
+        )))
+    }
+
+    fn repository_rule(
+        #[starlark(kwargs)] _kwargs: SmallMap<&str, Value>,
+        _eval: &mut Evaluator,
+    ) -> starlark::Result<NoneType> {
+        Err(starlark::Error::new_native(anyhow::anyhow!(
+            "repository_rule() unimplemented"
+        )))
+    }
+}

--- a/src/starlark/globals/mod.rs
+++ b/src/starlark/globals/mod.rs
@@ -1,1 +1,3 @@
+pub(crate) mod build;
+pub(crate) mod bzl;
 pub(crate) mod module;

--- a/src/starlark/mod.rs
+++ b/src/starlark/mod.rs
@@ -1,4 +1,5 @@
 // This file declares the starlark module and its submodules.
 
 pub(crate) mod builtins;
+pub(crate) mod eval;
 pub(crate) mod globals;

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -153,116 +153,46 @@ impl Workspace {
     ) -> impl Stream<Item = anyhow::Result<Label<'a>>> + 'a {
         let ws = self.clone();
 
-        let fut = async move {
-            let repo = match ws.main_repo().await {
-                Ok(r) => r,
-                Err(e) => return futures::stream::once(async move { Err(e) }).boxed(),
-            };
+        let labels_stream = async_stream::try_stream! {
+            let repo = ws.main_repo().await?;
 
-            let mut packages = Vec::new();
-            let base_dir = ws.path.clone();
-            if let Err(e) = walk_packages(base_dir.clone(), base_dir.clone(), &mut packages).await {
-                return futures::stream::once(async move { Err(anyhow::Error::from(e)) }).boxed();
+            let package_path = pattern.package.as_ref();
+            let root_pkg = repo.read_package(package_path).await?;
+
+            // Evaluate the root package
+            let rules = repo.eval_package(&root_pkg, ws.clone()).await?;
+            for rule_name in rules.into_keys() {
+                let label: Label<'a> = Label::new(
+                    Repo::Canonical(repo.canonical_name()),
+                    root_pkg.path.clone(),
+                    rule_name,
+                );
+
+                if pattern.matches(&label) {
+                    yield label;
+                }
             }
 
-            let packages_stream = futures::stream::iter(packages);
-            
-            let labels_stream = packages_stream.then(move |pkg| {
-                let ws_clone = ws.clone();
-                let repo_clone = repo.clone();
-                let pattern_clone = pattern.clone();
-                let base_dir_clone = base_dir.clone();
-                
-                async move {
-                    let build_path = if pkg.is_empty() {
-                        if tokio::fs::try_exists(base_dir_clone.join("BUILD.bazel")).await.unwrap_or(false) {
-                            "BUILD.bazel".to_string()
-                        } else {
-                            "BUILD".to_string()
-                        }
-                    } else {
-                        if tokio::fs::try_exists(base_dir_clone.join(&pkg).join("BUILD.bazel")).await.unwrap_or(false) {
-                            format!("{}/BUILD.bazel", pkg)
-                        } else {
-                            format!("{}/BUILD", pkg)
-                        }
-                    };
+            if pattern.include_subpackages {
+                let mut subpackages = root_pkg.subpackages();
+                while let Some(pkg) = subpackages.next().await {
+                    let pkg = pkg?;
+                    let rules = repo.eval_package(&pkg, ws.clone()).await?;
+                    for rule_name in rules.into_keys() {
+                        let label: Label<'a> = Label::new(
+                            Repo::Canonical(repo.canonical_name()),
+                            pkg.path.clone(),
+                            rule_name,
+                        );
 
-                    match crate::starlark::eval::eval_build(ws_clone, repo_clone.clone(), &build_path).await {
-                        Ok(rules) => {
-                            let mut matched = Vec::new();
-                            for rule_name in rules.keys() {
-                                let static_label = Label::new(
-                                    Repo::Canonical(repo_clone.canonical_name()),
-                                    pkg.clone(),
-                                    rule_name.clone(),
-                                );
-                                // Convert to 'a lifetime
-                                let label_a = {
-                                    let repo_a = match static_label.repo {
-                                        Repo::Apparent(r) => Repo::Apparent(crate::bazel::label::ApparentRepo::new(r.into_name())),
-                                        Repo::Canonical(r) => Repo::Canonical(crate::bazel::label::CanonicalRepo::new(r.into_name())),
-                                    };
-                                    Label::new(
-                                        repo_a,
-                                        static_label.package.into_owned(),
-                                        static_label.target.into_owned(),
-                                    )
-                                };
-
-                                if pattern_clone.matches(&label_a) {
-                                    matched.push(Ok(label_a));
-                                }
-                            }
-                            futures::stream::iter(matched).boxed()
+                        if pattern.matches(&label) {
+                            yield label;
                         }
-                        Err(e) => futures::stream::once(async move { Err(e) }).boxed(),
                     }
                 }
-            }).flatten();
-            
-            labels_stream.boxed()
+            }
         };
 
-        futures::stream::once(fut).flatten()
+        labels_stream
     }
-}
-
-#[async_recursion::async_recursion]
-async fn walk_packages(
-    dir: PathBuf,
-    base_dir: PathBuf,
-    packages: &mut Vec<String>,
-) -> anyhow::Result<()> {
-    let mut read_dir = tokio::fs::read_dir(&dir).await?;
-    let mut has_build = false;
-    let mut subdirs = Vec::new();
-
-    while let Some(entry) = read_dir.next_entry().await? {
-        let name = entry.file_name();
-        let name_str = name.to_string_lossy();
-        if name_str.starts_with('.') || name_str == "target" || name_str.starts_with("bazel-") {
-            continue;
-        }
-
-        let file_type = entry.file_type().await?;
-        if file_type.is_dir() {
-            subdirs.push(entry.path());
-        } else if file_type.is_file() {
-            if name_str == "BUILD" || name_str == "BUILD.bazel" {
-                has_build = true;
-            }
-        }
-    }
-
-    if has_build {
-        let rel_path = dir.strip_prefix(&base_dir)?;
-        packages.push(rel_path.to_string_lossy().into_owned());
-    }
-
-    for subdir in subdirs {
-        walk_packages(subdir, base_dir.clone(), packages).await?;
-    }
-
-    Ok(())
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,16 +1,19 @@
-use crate::bazel::label::{CanonicalRepo, MAIN_REPO};
+use crate::bazel::label::{CanonicalRepo, Label, MAIN_REPO, Repo, TargetPattern};
 use crate::bazel::package::{BoxFileStore, DynFileStore};
 use crate::bazel::repo::{LocalFileStore, Repository};
 use crate::shared_error::SharedError;
 use futures::TryFutureExt;
 use futures::future::{BoxFuture, Shared};
-use futures::stream::FuturesUnordered;
+use futures::stream::{FuturesUnordered, Stream};
 use futures::{FutureExt, StreamExt};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
+use starlark::environment::FrozenModule;
+
 type RepositoryFuture = Shared<BoxFuture<'static, Result<Arc<Repository<'static>>, SharedError>>>;
+type FrozenModuleFuture = Shared<BoxFuture<'static, Result<FrozenModule, SharedError>>>;
 
 /// The environment shared by all Bazel commands run in the same main repository. It encompasses the main repo and the set of all defined external repos.
 ///
@@ -18,6 +21,7 @@ type RepositoryFuture = Shared<BoxFuture<'static, Result<Arc<Repository<'static>
 pub struct Workspace {
     path: PathBuf,
     repositories: RwLock<HashMap<CanonicalRepo<'static>, RepositoryFuture>>,
+    loaded_deps: RwLock<HashMap<crate::bazel::label::CanonicalLabel<'static>, FrozenModuleFuture>>,
 }
 
 async fn any_exists(file1: impl AsRef<Path>, file2: impl AsRef<Path>) -> std::io::Result<bool> {
@@ -60,6 +64,7 @@ impl Workspace {
         let ws = Arc::new(Workspace {
             path: current_dir.clone(),
             repositories: RwLock::new(HashMap::new()),
+            loaded_deps: RwLock::new(HashMap::new()),
         });
 
         // Create the main repository
@@ -111,4 +116,153 @@ impl Workspace {
             .unwrap()
             .insert(repo, f.boxed().shared());
     }
+
+    pub fn get_or_add_bzl<Fut>(
+        &self,
+        label: crate::bazel::label::CanonicalLabel<'static>,
+        f: impl FnOnce() -> Fut,
+    ) -> FrozenModuleFuture
+    where
+        Fut: IntoFuture<Output = Result<FrozenModule, anyhow::Error>>,
+        Fut::IntoFuture: Send + 'static,
+    {
+        // First, check with read lock
+        if let Some(future) = self.loaded_deps.read().unwrap().get(&label) {
+            return future.clone();
+        }
+
+        // Retry with write lock and insert if still absent
+        let mut deps = self.loaded_deps.write().unwrap();
+        if let Some(future) = deps.get(&label) {
+            return future.clone();
+        }
+
+        let future = f()
+            .into_future()
+            .map_err(SharedError::from)
+            .boxed()
+            .shared();
+        deps.insert(label, future.clone());
+        future
+    }
+
+    /// Expand pattern into a stream of Labels
+    pub fn expand_pattern<'a>(
+        self: &Arc<Self>,
+        pattern: TargetPattern<'a>,
+    ) -> impl Stream<Item = anyhow::Result<Label<'a>>> + 'a {
+        let ws = self.clone();
+
+        let fut = async move {
+            let repo = match ws.main_repo().await {
+                Ok(r) => r,
+                Err(e) => return futures::stream::once(async move { Err(e) }).boxed(),
+            };
+
+            let mut packages = Vec::new();
+            let base_dir = ws.path.clone();
+            if let Err(e) = walk_packages(base_dir.clone(), base_dir.clone(), &mut packages).await {
+                return futures::stream::once(async move { Err(anyhow::Error::from(e)) }).boxed();
+            }
+
+            let packages_stream = futures::stream::iter(packages);
+            
+            let labels_stream = packages_stream.then(move |pkg| {
+                let ws_clone = ws.clone();
+                let repo_clone = repo.clone();
+                let pattern_clone = pattern.clone();
+                let base_dir_clone = base_dir.clone();
+                
+                async move {
+                    let build_path = if pkg.is_empty() {
+                        if tokio::fs::try_exists(base_dir_clone.join("BUILD.bazel")).await.unwrap_or(false) {
+                            "BUILD.bazel".to_string()
+                        } else {
+                            "BUILD".to_string()
+                        }
+                    } else {
+                        if tokio::fs::try_exists(base_dir_clone.join(&pkg).join("BUILD.bazel")).await.unwrap_or(false) {
+                            format!("{}/BUILD.bazel", pkg)
+                        } else {
+                            format!("{}/BUILD", pkg)
+                        }
+                    };
+
+                    match crate::starlark::eval::eval_build(ws_clone, repo_clone.clone(), &build_path).await {
+                        Ok(rules) => {
+                            let mut matched = Vec::new();
+                            for rule_name in rules.keys() {
+                                let static_label = Label::new(
+                                    Repo::Canonical(repo_clone.canonical_name()),
+                                    pkg.clone(),
+                                    rule_name.clone(),
+                                );
+                                // Convert to 'a lifetime
+                                let label_a = {
+                                    let repo_a = match static_label.repo {
+                                        Repo::Apparent(r) => Repo::Apparent(crate::bazel::label::ApparentRepo::new(r.into_name())),
+                                        Repo::Canonical(r) => Repo::Canonical(crate::bazel::label::CanonicalRepo::new(r.into_name())),
+                                    };
+                                    Label::new(
+                                        repo_a,
+                                        static_label.package.into_owned(),
+                                        static_label.target.into_owned(),
+                                    )
+                                };
+
+                                if pattern_clone.matches(&label_a) {
+                                    matched.push(Ok(label_a));
+                                }
+                            }
+                            futures::stream::iter(matched).boxed()
+                        }
+                        Err(e) => futures::stream::once(async move { Err(e) }).boxed(),
+                    }
+                }
+            }).flatten();
+            
+            labels_stream.boxed()
+        };
+
+        futures::stream::once(fut).flatten()
+    }
+}
+
+#[async_recursion::async_recursion]
+async fn walk_packages(
+    dir: PathBuf,
+    base_dir: PathBuf,
+    packages: &mut Vec<String>,
+) -> anyhow::Result<()> {
+    let mut read_dir = tokio::fs::read_dir(&dir).await?;
+    let mut has_build = false;
+    let mut subdirs = Vec::new();
+
+    while let Some(entry) = read_dir.next_entry().await? {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if name_str.starts_with('.') || name_str == "target" || name_str.starts_with("bazel-") {
+            continue;
+        }
+
+        let file_type = entry.file_type().await?;
+        if file_type.is_dir() {
+            subdirs.push(entry.path());
+        } else if file_type.is_file() {
+            if name_str == "BUILD" || name_str == "BUILD.bazel" {
+                has_build = true;
+            }
+        }
+    }
+
+    if has_build {
+        let rel_path = dir.strip_prefix(&base_dir)?;
+        packages.push(rel_path.to_string_lossy().into_owned());
+    }
+
+    for subdir in subdirs {
+        walk_packages(subdir, base_dir.clone(), packages).await?;
+    }
+
+    Ok(())
 }

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -13,3 +13,42 @@ fn test_query_basic_hello_world() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[test]
+fn test_query_basic_nested_hello_world() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("razel"));
+    cmd.current_dir("examples/basic");
+
+    cmd.arg("query").arg("//nested:hello_world_nested");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("//nested:hello_world"));
+
+    Ok(())
+}
+
+#[test]
+fn test_query_basic_notfound() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("razel"));
+    cmd.current_dir("examples/basic");
+
+    cmd.arg("query").arg("//:not_exist");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("//:hello_world").not());
+
+    Ok(())
+}
+
+#[test]
+fn test_query_dots() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("razel"));
+    cmd.current_dir("examples/basic");
+
+    cmd.arg("query").arg("//...");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("//:hello_world"));
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Stream target-pattern expansion package by package instead of collecting all packages and labels first.
- Evaluate BUILD files and recursively loaded `.bzl` files to collect queryable rule targets.
- Discover subpackages through the `FileStore` abstraction, allowing the same traversal for local and in-memory repositories.
- Resolve apparent repositories in Starlark load labels through each repository's mapping.

## Implementation

- Adds typed file and directory entries plus package path/build-file metadata.
- Walks subpackages incrementally and evaluates each package before advancing the stream.
- Caches shared `.bzl` evaluation futures by canonical label to deduplicate recursive loads.
- Adds owned label conversions for async boundaries while borrowing mapped canonical repository names during normal resolution.
- Keeps package evaluation safe with a static repository bound rather than lifetime transmutation.
- Updates query evaluation to consume the label stream directly.

## Current scope

- BUILD evaluation currently recognizes `genrule`, `cc_library`, `cc_binary`, `filegroup`, and `sh_binary` targets.
- Recursive expansion requires the pattern's starting package to contain a BUILD file.

## Testing

- `cargo test` (62 tests passed)
- `cargo fmt --all -- --check`
